### PR TITLE
Update cyberark_authentication.py

### DIFF
--- a/plugins/modules/cyberark_authentication.py
+++ b/plugins/modules/cyberark_authentication.py
@@ -185,6 +185,7 @@ def processAuthentication(module):
 
         if use_ldap:
             end_point = "/PasswordVault/API/Auth/LDAP/Logon"
+            payload_dict = {"username": username, "password": password}
 
         elif use_radius:
             end_point = "/PasswordVault/API/Auth/radius/Logon"


### PR DESCRIPTION
Added the line 188, to send the payload with username and password.

The payload is empty when authenticating with LDAP, causing an error. When I added the payload, it authenticated as expected.